### PR TITLE
feat(search): use Game::search over Game::where

### DIFF
--- a/app/Http/Livewire/IgdbSearch.php
+++ b/app/Http/Livewire/IgdbSearch.php
@@ -60,10 +60,7 @@ class IgdbSearch extends Component
 
         $searchTerm = trim(Str::limit($this->searchName, 50));
         if (Str::length($searchTerm) >= 3) {
-            $searchQuery = Game::where(function ($query) use ($searchTerm) {
-                $query->whereLike('name', $searchTerm, false)
-                    ->orWhereLike('alternative_names.name', $searchTerm, false);
-            });
+            $searchQuery = Game::search($searchTerm);
 
             if (!empty($this->searchYear) && strlen($this->searchYear) == 4) {
                 $searchQuery->whereYear('first_release_date', trim($this->searchYear));


### PR DESCRIPTION
In some very basic benchmarking, `Game::search` returns a result ~3x faster than `Game::where` at the cost of losing the ability to search `alternative_names.name `. 

Will need to run some tests if everything shows up as expected on the search. 